### PR TITLE
Allow zipping the pack with Unix shell script

### DIFF
--- a/zip-pack.sh
+++ b/zip-pack.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+mkdir -p output
+
+rm -f MetroidZeroMission_PopTrackerPack.zip
+rm -rf output/*
+
+files="images items layouts locations maps scripts manifest.json settings.json"
+cp -r $files output
+
+cd output
+zip -r ../MetroidZeroMission_PopTrackerPack.zip *


### PR DESCRIPTION
Adds zip-pack.sh as an alternative to zip-pack.ps1 to zip the pack on Mac and Linux systems.